### PR TITLE
Rebuild msitools 0.100 with libxml2 2.10

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-# Remove this tag when the underlying issue https://github.com/anaconda-distribution/rocket-platform/pull/751
-# will be resolved.
-pkg_build_image_tag: '2023.03.24'

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+# Remove this tag when the underlying issue https://github.com/anaconda-distribution/rocket-platform/pull/751
+# will be resolved.
+pkg_build_image_tag: '2023.03.24'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,14 +28,14 @@ requirements:
     - perl 5.*
     - pkg-config
   host:
-    - gcab
-    - gettext  # [osx]
+    - gcab 1.4
+    - gettext 0.21.0  # [osx]
     - glib
-    - libgsf 1.14.*
-    - libuuid <2
+    - libgsf 1.14
+    - libuuid 1.41.5
     - libxml2 2.10
   run:
-    - gettext  # [osx]
+    - gettext >=0.21.0,<1.0a0  # [osx]
     - libgsf >=1.14,<1.15
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: http://ftp.gnome.org/pub/GNOME/sources/msitools/{{ version }}/msitools-{{ version }}.tar.xz
+  url: https://ftp.gnome.org/pub/GNOME/sources/msitools/{{ version }}/msitools-{{ version }}.tar.xz
   sha256: bbf1a6e3a9c2323b860a3227ac176736a3eafc4a44a67346c6844591f10978ea
   patches:  # [osx]
     - byte-order-osx.patch  # [osx]
@@ -24,7 +24,7 @@ requirements:
     - gawk
     - gnuconfig
     - make
-    - patch     # [not win]
+    - patch     # [osx]
     - perl 5.*
     - pkg-config
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,36 +8,35 @@ package:
 source:
   url: http://ftp.gnome.org/pub/GNOME/sources/msitools/{{ version }}/msitools-{{ version }}.tar.xz
   sha256: bbf1a6e3a9c2323b860a3227ac176736a3eafc4a44a67346c6844591f10978ea
-  patches:
-    - byte-order-osx.patch
+  patches:  # [osx]
+    - byte-order-osx.patch  # [osx]
 
 build:
-  number: 0
+  number: 1
   # Not supported on win
   skip: True   # [win]
 
 requirements:
   build:
-    - gnuconfig
     - {{ compiler('c') }}
-    - make
     - bison
-    - gawk
     - flex
-    - pkg-config
+    - gawk
+    - gnuconfig
+    - make
     - patch     # [not win]
-    - m2-patch  # [win]
-    - perl
+    - perl 5.*
+    - pkg-config
   host:
+    - gcab
+    - gettext  # [osx]
+    - glib
     - libgsf 1.14.*
     - libuuid <2
-    - libxml2
-    - gcab
-    - glib
-    - gettext  # [osx]
+    - libxml2 2.10
   run:
-    - libgsf >=1.14,<1.15
     - gettext  # [osx]
+    - libgsf >=1.14,<1.15
 
 test:
   commands:


### PR DESCRIPTION
Actions:
1. Fix source/url
2. Apply a patch only on osx
3. Reorder dependencies
4. Add libxml2 pinning 